### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-colors.css
+++ b/docs/stylesheets/eb-brand-colors.css
@@ -1,0 +1,16 @@
+/* Auto-generated from eb-brand tokens */
+:root {
+  --md-primary-fg-color: var(--eb-light-brand-primary);
+  --md-accent-fg-color: var(--eb-light-brand-accent);
+
+  --md-default-bg-color: var(--eb-light-background-canvas);
+  --md-default-fg-color: var(--eb-light-text-primary);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--eb-dark-brand-primary);
+  --md-accent-fg-color: var(--eb-dark-brand-accent);
+
+  --md-default-bg-color: var(--eb-dark-background-canvas);
+  --md-default-fg-color: var(--eb-dark-text-primary);
+}


### PR DESCRIPTION
Automated sync from `eb-brand` commit `4b432d41cf3e1229fac3d879c5e4619315e29aac`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat this file as read-only