### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-tokens.css
+++ b/docs/stylesheets/eb-brand-tokens.css
@@ -1,0 +1,22 @@
+:root {
+  --eb-light-background-canvas: #F8FAFC;
+  --eb-light-background-surface: #EEF2F7;
+  --eb-light-background-divider: #D6DCE5;
+  --eb-light-text-primary: #111827;
+  --eb-light-text-secondary: #4B5563;
+  --eb-light-text-muted: #6B7280;
+  --eb-light-brand-primary: #2E4A62;
+  --eb-light-brand-primary_muted: #5E7387;
+  --eb-light-brand-accent: #C9A227;
+  --eb-light-brand-accent_muted: #E6D38A;
+  --eb-dark-background-canvas: #0B0F14;
+  --eb-dark-background-surface: #111827;
+  --eb-dark-background-divider: #1F2937;
+  --eb-dark-text-primary: #E5E7EB;
+  --eb-dark-text-secondary: #9CA3AF;
+  --eb-dark-text-muted: #6B7280;
+  --eb-dark-brand-primary: #5B7C99;
+  --eb-dark-brand-primary_muted: #3E5A73;
+  --eb-dark-brand-accent: #D4AF37;
+  --eb-dark-brand-accent_muted: #A38B2E;
+}


### PR DESCRIPTION
Automated sync from `eb-brand` commit `3f15c7e632bf4305060318eae0e69cdd52e62589`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only