### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-colors.css
+++ b/docs/stylesheets/eb-brand-colors.css
@@ -1,14 +1,24 @@
 /* Auto-generated from eb-brand tokens */
+
 :root {
+  /* Primary (header, tabs) */
   --md-primary-fg-color: var(--eb-light-brand-primary);
+  --md-primary-bg-color: var(--eb-light-brand-primary);
+  --md-primary-bg-color--light: var(--eb-light-brand-primary);
+
+  /* Accent */
   --md-accent-fg-color: var(--eb-light-brand-accent);
 
+  /* Page */
   --md-default-bg-color: var(--eb-light-background-canvas);
   --md-default-fg-color: var(--eb-light-text-primary);
 }
 
 [data-md-color-scheme="slate"] {
   --md-primary-fg-color: var(--eb-dark-brand-primary);
+  --md-primary-bg-color: var(--eb-dark-brand-primary);
+  --md-primary-bg-color--light: var(--eb-dark-brand-primary);
+
   --md-accent-fg-color: var(--eb-dark-brand-accent);
 
   --md-default-bg-color: var(--eb-dark-background-canvas);


### PR DESCRIPTION
Automated sync from `eb-brand` commit `66ff4210573fb11fd2334e5742f0a2ec78a29022`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only