### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-colors.css
+++ b/docs/stylesheets/eb-brand-colors.css
@@ -1,10 +1,14 @@
 /* Auto-generated from eb-brand tokens */
 
+/* ---------------------------
+   Light mode (default)
+--------------------------- */
 :root {
-  /* Primary (header, tabs) */
-  --md-primary-fg-color: var(--eb-light-brand-primary);
+  /* Header / primary */
   --md-primary-bg-color: var(--eb-light-brand-primary);
   --md-primary-bg-color--light: var(--eb-light-brand-primary);
+  --md-primary-bg-color--dark: var(--eb-light-brand-primary);
+  --md-primary-fg-color: var(--eb-light-text-on-brand);
 
   /* Accent */
   --md-accent-fg-color: var(--eb-light-brand-accent);
@@ -14,10 +18,14 @@
   --md-default-fg-color: var(--eb-light-text-primary);
 }
 
+/* ---------------------------
+   Dark mode (slate)
+--------------------------- */
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color: var(--eb-dark-brand-primary);
   --md-primary-bg-color: var(--eb-dark-brand-primary);
   --md-primary-bg-color--light: var(--eb-dark-brand-primary);
+  --md-primary-bg-color--dark: var(--eb-dark-brand-primary);
+  --md-primary-fg-color: var(--eb-dark-text-on-brand);
 
   --md-accent-fg-color: var(--eb-dark-brand-accent);
 


### PR DESCRIPTION
Automated sync from `eb-brand` commit `55b0ec7be012262a3374e6df0e4cc3faf097240d`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only