### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-tokens.css
+++ b/docs/stylesheets/eb-brand-tokens.css
@@ -1,6 +1,7 @@
 :root {
   --eb-light-background-canvas: #F8FAFC;
   --eb-light-background-surface: #EEF2F7;
+  --eb-light-background-header: #243E56;
   --eb-light-background-divider: #D6DCE5;
   --eb-light-text-primary: #111827;
   --eb-light-text-secondary: #4B5563;
@@ -11,6 +12,7 @@
   --eb-light-brand-accent_muted: #E6D38A;
   --eb-dark-background-canvas: #0B0F14;
   --eb-dark-background-surface: #111827;
+  --eb-dark-background-header: #3B5670;
   --eb-dark-background-divider: #1F2937;
   --eb-dark-text-primary: #E5E7EB;
   --eb-dark-text-secondary: #9CA3AF;


### PR DESCRIPTION
Automated sync from `eb-brand` commit `4704747825df7c194bf63b9aa8dc7d4b1df3b675`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only