### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-tokens.css
+++ b/docs/stylesheets/eb-brand-tokens.css
@@ -6,6 +6,7 @@
   --eb-light-text-primary: #0F172A;
   --eb-light-text-secondary: #334155;
   --eb-light-text-muted: #475569;
+  --eb-light-text-on_brand: #FFFFFF;
   --eb-light-brand-primary: #1098D4;
   --eb-light-brand-primary_muted: #2364A7;
   --eb-light-brand-accent: #F0BC2E;
@@ -17,6 +18,7 @@
   --eb-dark-text-primary: #E5E7EB;
   --eb-dark-text-secondary: #9CA3AF;
   --eb-dark-text-muted: #6B7280;
+  --eb-dark-text-on_brand: #E5E7EB;
   --eb-dark-brand-primary: #0C96D4;
   --eb-dark-brand-primary_muted: #2364A7;
   --eb-dark-brand-accent: #F4C940;


### PR DESCRIPTION
Automated sync from `eb-brand` commit `03229f6d992cbfb0fdd9b2c8122e18e7b1978617`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only