### PR TITLE
chore(brand): sync brand assets and color tokens

### DIFF
--- a/docs/stylesheets/eb-brand-colors.css
+++ b/docs/stylesheets/eb-brand-colors.css
@@ -5,30 +5,30 @@
 --------------------------- */
 :root {
   /* Header / primary */
-  --md-primary-bg-color: var(--eb-light-background-header);
-  --md-primary-bg-color--light: var(--eb-light-background-header);
-  --md-primary-bg-color--dark: var(--eb-light-background-header);
-  --md-primary-fg-color: var(--eb-light-text-on-brand);
+  --md-primary-fg-color:        var(--eb-light-background-header);
+  --md-primary-fg-color--light:  var(--eb-light-background-header);
+  --md-primary-fg-color--dark:   var(--eb-light-background-header);
+  --md-primary-bg-color:        var(--eb-light-text-on-brand);
 
   /* Accent */
-  --md-accent-fg-color: var(--eb-light-brand-accent);
+  --md-accent-fg-color:         var(--eb-light-brand-accent);
 
   /* Page */
-  --md-default-bg-color: var(--eb-light-background-canvas);
-  --md-default-fg-color: var(--eb-light-text-primary);
+  --md-default-bg-color:        var(--eb-light-background-canvas);
+  --md-default-fg-color:        var(--eb-light-text-primary);
 }
 
 /* ---------------------------
    Dark mode (slate)
 --------------------------- */
 [data-md-color-scheme="slate"] {
-  --md-primary-bg-color: var(--eb-dark-background-header);
-  --md-primary-bg-color--light: var(--eb-dark-background-header);
-  --md-primary-bg-color--dark: var(--eb-dark-background-header);
-  --md-primary-fg-color: var(--eb-dark-text-on-brand);
+  --md-primary-fg-color:        var(--eb-dark-background-header);
+  --md-primary-fg-color--light:  var(--eb-dark-background-header);
+  --md-primary-fg-color--dark:   var(--eb-dark-background-header);
+  --md-primary-bg-color:        var(--eb-dark-text-on-brand);
 
-  --md-accent-fg-color: var(--eb-dark-brand-accent);
+  --md-accent-fg-color:         var(--eb-dark-brand-accent);
 
-  --md-default-bg-color: var(--eb-dark-background-canvas);
-  --md-default-fg-color: var(--eb-dark-text-primary);
+  --md-default-bg-color:        var(--eb-dark-background-canvas);
+  --md-default-fg-color:        var(--eb-dark-text-primary);
 }


### PR DESCRIPTION
Automated sync from `eb-brand` commit `15ea67297625fbafb612e403bf35d970320e2f06`.

Source:
- `electric-barometer/favicon/`
- `electric-barometer/icons/`
- `electric-barometer/logo/`
- Generated from `electric-barometer/tokens/colors.json`

Destination:
- `docs/assets/brand/`
- `docs/stylesheets/eb-brand-tokens.css`
- `docs/stylesheets/eb-brand-colors.css`

Notes:
- CSS is auto-generated via `build_colors.py`
- Downstream repos should treat these files as read-only